### PR TITLE
_idの除去処理を追加

### DIFF
--- a/cmd/importer/main.go
+++ b/cmd/importer/main.go
@@ -71,7 +71,7 @@ func main() {
 	fileUtils := utils.NewFileUtils(nil) // Use actual file system
 
 	// Initialize importer service
-	importer := service.NewMongoImporter(ctx, fileUtils, repo, cfg.BatchSize)
+	importer := service.NewMongoImporterWithOptions(ctx, fileUtils, repo, cfg.BatchSize, true)
 
 	// Execute import process
 	startTime := time.Now()

--- a/internal/service/importer_test.go
+++ b/internal/service/importer_test.go
@@ -149,7 +149,7 @@ func TestImportFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create importer with mocks
-			importer := NewMongoImporter(ctx, tt.mockFileUtils, tt.mockRepo, 100)
+			importer := NewMongoImporterWithOptions(ctx, tt.mockFileUtils, tt.mockRepo, 100, false)
 
 			// Call the method
 			result, err := importer.ImportFile(tt.filePath)
@@ -320,7 +320,7 @@ func TestImportDirectory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create importer with mocks
-			importer := NewMongoImporter(ctx, tt.mockFileUtils, tt.mockRepo, 100)
+			importer := NewMongoImporterWithOptions(ctx, tt.mockFileUtils, tt.mockRepo, 100, false)
 
 			// Call the method
 			results, err := importer.ImportDirectory(tt.dirPath)
@@ -445,7 +445,7 @@ func TestImportPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create importer with mocks
-			importer := NewMongoImporter(ctx, tt.mockFileUtils, tt.mockRepo, 100)
+			importer := NewMongoImporterWithOptions(ctx, tt.mockFileUtils, tt.mockRepo, 100, false)
 
 			// Call the method
 			result, err := importer.ImportPath(tt.path)
@@ -549,7 +549,7 @@ func TestProcessBatches(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create importer with mocks
-			importer := NewMongoImporter(ctx, &MockFileUtils{}, tt.mockRepo, tt.batchSize)
+			importer := NewMongoImporterWithOptions(ctx, &MockFileUtils{}, tt.mockRepo, tt.batchSize, false)
 
 			// Call the method directly (it's private, but we can access it in tests)
 			count, err := importer.processBatches(tt.documents, "test_collection")

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -73,7 +73,7 @@ func TestIntegration(t *testing.T) {
 	fileUtils := utils.NewFileUtils(nil) // Use actual file system
 
 	// Initialize importer service with batch size from config
-	importer := service.NewMongoImporter(ctx, fileUtils, repo, cfg.BatchSize)
+	importer := service.NewMongoImporterWithOptions(ctx, fileUtils, repo, cfg.BatchSize, true)
 
 	// Run subtests
 	t.Run("ImportArrayJSON", func(t *testing.T) {


### PR DESCRIPTION
This pull request introduces several key changes to the `MongoImporter` service to enhance its functionality and flexibility. The most important changes include adding an option to remove `_id` fields from documents, updating the `ImporterService` interface, and modifying related tests to accommodate the new option.

Enhancements to `MongoImporter` service:

* [`internal/service/importer.go`](diffhunk://#diff-91ee624be1902640252647549fdf747370211e4480c8efc7b7c3127aefad3af0L45-R45): Added a new constructor `NewMongoImporterWithOptions` that includes an option to remove `_id` fields from documents during import. Updated the `cleanDocuments` method to handle the new `removeIDField` option and added detailed logging for `_id` field processing. [[1]](diffhunk://#diff-91ee624be1902640252647549fdf747370211e4480c8efc7b7c3127aefad3af0L45-R45) [[2]](diffhunk://#diff-91ee624be1902640252647549fdf747370211e4480c8efc7b7c3127aefad3af0R56) [[3]](diffhunk://#diff-91ee624be1902640252647549fdf747370211e4480c8efc7b7c3127aefad3af0L178-R220)

Interface updates:

* [`internal/service/importer.go`](diffhunk://#diff-91ee624be1902640252647549fdf747370211e4480c8efc7b7c3127aefad3af0L23-R23): Updated the `ImportPath` method in the `ImporterService` interface to return `any` instead of `interface{}` to improve type safety and readability.

Test modifications:

* [`internal/service/importer_test.go`](diffhunk://#diff-81750b69f6667c29b5d6d15886bd805c64e8ecc24ff9eab672ff0ae36b2380f7L152-R152): Updated all test cases to use the new `NewMongoImporterWithOptions` constructor, ensuring they reflect the changes in the `MongoImporter` service. [[1]](diffhunk://#diff-81750b69f6667c29b5d6d15886bd805c64e8ecc24ff9eab672ff0ae36b2380f7L152-R152) [[2]](diffhunk://#diff-81750b69f6667c29b5d6d15886bd805c64e8ecc24ff9eab672ff0ae36b2380f7L323-R323) [[3]](diffhunk://#diff-81750b69f6667c29b5d6d15886bd805c64e8ecc24ff9eab672ff0ae36b2380f7L448-R448) [[4]](diffhunk://#diff-81750b69f6667c29b5d6d15886bd805c64e8ecc24ff9eab672ff0ae36b2380f7L552-R552)
* [`tests/integration/integration_test.go`](diffhunk://#diff-e4ede531ad8643dc7af3ffb5ddf644bdfa5c2f8a45430f580f0fa687ffab06efL76-R76): Modified the integration test to use the `NewMongoImporterWithOptions` constructor with the `removeIDField` option enabled.

Main function update:

* [`cmd/importer/main.go`](diffhunk://#diff-549314da91cc8b123070944ea00e90184c09c49a71744f00d526c25859edd05cL74-R74): Updated the main function to initialize the `MongoImporter` service using the new `NewMongoImporterWithOptions` constructor with the `removeIDField` option enabled.