### PR TITLE
Convert date fields to time.Time for proper MongoDB date type handling

### DIFF
--- a/internal/service/importer.go
+++ b/internal/service/importer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"sync"
 	"time"
 
@@ -196,7 +197,74 @@ func (m *MongoImporter) cleanDocuments(documents []domain.Document) []domain.Doc
 			// 	fmt.Printf("WARNING: Document %d still has _id after deletion!\n", i)
 			// }
 		}
+
+		// 各フィールドを再帰的に処理して日付を変換
+		documents[i] = m.processDocumentDates(documents[i])
 	}
 
 	return documents
+}
+
+// processDocumentDates recursively processes all fields in a document
+// converting date strings and MongoDB's $date format to time.Time objects
+func (m *MongoImporter) processDocumentDates(doc domain.Document) domain.Document {
+	for key, value := range doc {
+		switch v := value.(type) {
+		case map[string]interface{}:
+			// $dateフィールドを持つオブジェクトをチェック
+			if dateStr, ok := v["$date"]; ok {
+				if ds, ok := dateStr.(string); ok {
+					// 日付文字列をtime.Time型に変換
+					t, err := parseDateTime(ds)
+					if err == nil {
+						// time.Time型をセット (MongoDB ドライバーが自動的に日付型として扱う)
+						doc[key] = t
+					} else {
+						fmt.Printf("Warning: Failed to parse date string '%s': %v\n", ds, err)
+					}
+				}
+			} else {
+				// ネストされたマップを再帰的に処理
+				doc[key] = m.processDocumentDates(v)
+			}
+		case string:
+			// 文字列が日付形式かチェック
+			if isDateString(v) {
+				t, err := parseDateTime(v)
+				if err == nil {
+					doc[key] = t
+				}
+			}
+		}
+	}
+	return doc
+}
+
+// parseDateTime parses a date string in various formats
+func parseDateTime(dateStr string) (time.Time, error) {
+	formats := []string{
+		time.RFC3339,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.000Z",
+		"2006-01-02",
+	}
+
+	for _, format := range formats {
+		t, err := time.Parse(format, dateStr)
+		if err == nil {
+			return t, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("unable to parse date: %s", dateStr)
+}
+
+// isDateString checks if a string is in ISO date format
+func isDateString(s string) bool {
+	// ISO 8601形式の日付文字列をチェック
+	matched, _ := regexp.MatchString(
+		`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$`,
+		s)
+
+	return matched
 }

--- a/internal/service/importer.go
+++ b/internal/service/importer.go
@@ -186,35 +186,15 @@ func (m *MongoImporter) cleanDocuments(documents []domain.Document) []domain.Doc
 			idCount++
 
 			// _idの種類も確認
-			fmt.Printf("Document %d has _id of type %T: %v\n",
-				i, documents[i]["_id"], documents[i]["_id"])
+			// fmt.Printf("Document %d has _id of type %T: %v\n",
+			// 	i, documents[i]["_id"], documents[i]["_id"])
 
 			delete(documents[i], "_id")
 
 			// 削除後に確認
-			if _, stillHasID := documents[i]["_id"]; stillHasID {
-				fmt.Printf("WARNING: Document %d still has _id after deletion!\n", i)
-			}
-		}
-
-		// Convert to string from date type
-		for key, value := range documents[i] {
-			if value, ok := value.(map[string]any); ok {
-				// $dataフィールドが存在するか確認
-				if dateValue, hasDate := value["$date"]; hasDate {
-					// $dateフィールドが存在する場合は、string型に変換
-					var dateStr string
-					switch v := dateValue.(type) {
-					case string:
-						dateStr = v
-					case float64:
-						dateStr = fmt.Sprintf("%d", int(v))
-					default:
-						dateStr = fmt.Sprintf("%v", v)
-					}
-					documents[i][key] = dateStr
-				}
-			}
+			// if _, stillHasID := documents[i]["_id"]; stillHasID {
+			// 	fmt.Printf("WARNING: Document %d still has _id after deletion!\n", i)
+			// }
 		}
 	}
 

--- a/internal/service/importer_test.go
+++ b/internal/service/importer_test.go
@@ -611,7 +611,7 @@ func TestCleanDocuments(t *testing.T) {
 			removeIDField: true,
 		},
 		{
-			name: "Date Conversion: Convert $date fields",
+			name: "Date Fields: Preserve $date fields",
 			input: []domain.Document{
 				{
 					"_id":        map[string]any{"$oid": "67aea3a5369bca5b08f38a67"},
@@ -623,8 +623,8 @@ func TestCleanDocuments(t *testing.T) {
 			expected: []domain.Document{
 				{
 					"name":       "Document with dates",
-					"created_at": "2024-05-22T16:04:35.000Z",
-					"updated_at": "2024-05-23T10:15:20.000Z",
+					"created_at": map[string]any{"$date": "2024-05-22T16:04:35.000Z"},
+					"updated_at": map[string]any{"$date": "2024-05-23T10:15:20.000Z"},
 				},
 			},
 			removeIDField: true,
@@ -668,8 +668,8 @@ func TestCleanDocuments(t *testing.T) {
 					"business_form_type": "CORPORATION",
 					"tel":                "080-9966-0373",
 					"zip":                "1530064",
-					"created_at":         "2014-02-19T14:24:08.000Z",
-					"updated_at":         "2024-05-22T16:04:35.000Z",
+					"created_at":         map[string]any{"$date": "2014-02-19T14:24:08.000Z"},
+					"updated_at":         map[string]any{"$date": "2024-05-22T16:04:35.000Z"},
 					"division_type":      nil,
 					"buyer_team_id":      4,
 				},

--- a/internal/service/importer_test.go
+++ b/internal/service/importer_test.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/OTakumi/data-importer/internal/domain"
-	// "github.com/OTakumi/data-importer/internal/utils"
 )
 
 // MockFileUtils is a mock implementation of the file utilities for testing
@@ -571,11 +571,22 @@ func TestProcessBatches(t *testing.T) {
 }
 
 // TestCleanDocuments tests the cleanDocuments function
+// TestCleanDocuments tests the cleanDocuments function
 func TestCleanDocuments(t *testing.T) {
 	// Create a basic importer instance for testing
 	importer := &MongoImporter{
 		removeIDField: true,
 	}
+
+	// パースに使う基準時間
+	dateStr1 := "2024-05-22T16:04:35.000Z"
+	timeObj1, _ := time.Parse(time.RFC3339, dateStr1)
+
+	dateStr2 := "2024-05-23T10:15:20.000Z"
+	timeObj2, _ := time.Parse(time.RFC3339, dateStr2)
+
+	dateStr3 := "2014-02-19T14:24:08.000Z"
+	timeObj3, _ := time.Parse(time.RFC3339, dateStr3)
 
 	// Test cases
 	tests := []struct {
@@ -611,7 +622,7 @@ func TestCleanDocuments(t *testing.T) {
 			removeIDField: true,
 		},
 		{
-			name: "Date Fields: Preserve $date fields",
+			name: "Date Fields: Convert $date fields to time.Time",
 			input: []domain.Document{
 				{
 					"_id":        map[string]any{"$oid": "67aea3a5369bca5b08f38a67"},
@@ -623,8 +634,8 @@ func TestCleanDocuments(t *testing.T) {
 			expected: []domain.Document{
 				{
 					"name":       "Document with dates",
-					"created_at": map[string]any{"$date": "2024-05-22T16:04:35.000Z"},
-					"updated_at": map[string]any{"$date": "2024-05-23T10:15:20.000Z"},
+					"created_at": timeObj1,
+					"updated_at": timeObj2,
 				},
 			},
 			removeIDField: true,
@@ -668,8 +679,8 @@ func TestCleanDocuments(t *testing.T) {
 					"business_form_type": "CORPORATION",
 					"tel":                "080-9966-0373",
 					"zip":                "1530064",
-					"created_at":         map[string]any{"$date": "2014-02-19T14:24:08.000Z"},
-					"updated_at":         map[string]any{"$date": "2024-05-22T16:04:35.000Z"},
+					"created_at":         timeObj3,
+					"updated_at":         timeObj1,
 					"division_type":      nil,
 					"buyer_team_id":      4,
 				},
@@ -711,7 +722,12 @@ func TestCleanDocuments(t *testing.T) {
 
 			// Check results
 			if !reflect.DeepEqual(result, tt.expected) {
-				t.Errorf("Expected %+v, got %+v", tt.expected, result)
+				t.Errorf("Expected\n%+v\ngot\n%+v", tt.expected, result)
+
+				// 実際の型情報を表示して確認
+				for k, v := range result[0] {
+					t.Logf("Field %s: Type %T, Value %v", k, v, v)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This pull request introduces significant changes to the `MongoImporter` class in the `internal/service/importer.go` file to improve the handling of date fields in documents. Additionally, it includes updates to the corresponding test cases in `internal/service/importer_test.go`.

Improvements to date handling:

* [`internal/service/importer.go`](diffhunk://#diff-91ee624be1902640252647549fdf747370211e4480c8efc7b7c3127aefad3af0L189-R269): Added the `processDocumentDates` method to recursively process all fields in a document, converting date strings and MongoDB's `$date` format to `time.Time` objects.
* [`internal/service/importer.go`](diffhunk://#diff-91ee624be1902640252647549fdf747370211e4480c8efc7b7c3127aefad3af0L189-R269): Introduced the `parseDateTime` function to parse date strings in various formats and the `isDateString` function to check if a string is in ISO date format.

Updates to test cases:

* [`internal/service/importer_test.go`](diffhunk://#diff-81750b69f6667c29b5d6d15886bd805c64e8ecc24ff9eab672ff0ae36b2380f7R573-R590): Updated the `TestCleanDocuments` function to include test cases for the new date conversion logic, using `time.Time` objects instead of date strings. [[1]](diffhunk://#diff-81750b69f6667c29b5d6d15886bd805c64e8ecc24ff9eab672ff0ae36b2380f7R573-R590) [[2]](diffhunk://#diff-81750b69f6667c29b5d6d15886bd805c64e8ecc24ff9eab672ff0ae36b2380f7L614-R625) [[3]](diffhunk://#diff-81750b69f6667c29b5d6d15886bd805c64e8ecc24ff9eab672ff0ae36b2380f7L626-R638) [[4]](diffhunk://#diff-81750b69f6667c29b5d6d15886bd805c64e8ecc24ff9eab672ff0ae36b2380f7L671-R683)
* [`internal/service/importer_test.go`](diffhunk://#diff-81750b69f6667c29b5d6d15886bd805c64e8ecc24ff9eab672ff0ae36b2380f7L714-R730): Enhanced the error message in `TestCleanDocuments` to display actual type information for better debugging.

Minor changes:

* [`internal/service/importer.go`](diffhunk://#diff-91ee624be1902640252647549fdf747370211e4480c8efc7b7c3127aefad3af0R7): Added the `regexp` package to support the `isDateString` function.
* [`internal/service/importer_test.go`](diffhunk://#diff-81750b69f6667c29b5d6d15886bd805c64e8ecc24ff9eab672ff0ae36b2380f7R8-L10): Added the `time` package to support the new test cases.